### PR TITLE
bugfix: run() method is not returning status code

### DIFF
--- a/src/Wrep/Daemonizable/Command/EndlessCommand.php
+++ b/src/Wrep/Daemonizable/Command/EndlessCommand.php
@@ -64,7 +64,7 @@ abstract class EndlessCommand extends Command
 		}
 
 		// And now run the command
-		parent::run($input, $output);
+		return parent::run($input, $output);
 	}
 
 	/**


### PR DESCRIPTION
Method run() should return status code as parent do.
