### PR TITLE
Update EndlessCommand.php

### DIFF
--- a/src/Wrep/Daemonizable/Command/EndlessCommand.php
+++ b/src/Wrep/Daemonizable/Command/EndlessCommand.php
@@ -213,7 +213,7 @@ abstract class EndlessCommand extends Command
 	/**
 	 * @see Symfony\Component\Console\Command\Command::setCode()
 	 */
-	public function setCode(callable $code)
+	public function setCode($code)
 	{
 		// Exact copy of our parent
 		// Makes sure we can access to call it every iteration


### PR DESCRIPTION
Hello,

thank you very much for your work, I use it and it works fine.
However, I want to upgrade my project dependencies and signature of method setCode is different between Wrep\Daemonizable\Command\EndlessCommand and Symfony\Component\Console\Command\Command

In symfony class, parameter $code is not typehint as callable, so I removed it here.
Is it good for you? Can you merge it to allow me to upgrade my dependencies?

Thanks in advance,