### PR TITLE
Removed calleable typehint.

### DIFF
--- a/src/Wrep/Daemonizable/Command/EndlessCommand.php
+++ b/src/Wrep/Daemonizable/Command/EndlessCommand.php
@@ -213,7 +213,7 @@ abstract class EndlessCommand extends Command
 	/**
 	 * @see Symfony\Component\Console\Command\Command::setCode()
 	 */
-	public function setCode(callable $code)
+	public function setCode($code)
 	{
 		// Exact copy of our parent
 		// Makes sure we can access to call it every iteration


### PR DESCRIPTION
I did this because there's an if to check if it's callable anyway and more importantly when I tried to do composer update on my symfony2 project I got the following error:

Declaration of Wrep\Daemonizable\Command\EndlessCommand::setCode() should be compatible with Symfony\Component\Console\Command\Command::setCode($code)