### PR TITLE
Fixing Symfony ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Use composer to include it into your Symfony2 project:
 
 ### What version to use?
 Symfony did make some breaking changes, so you should make sure to use a compatible bundle version:
-* Version 1.3.* for Symfony 3.0 and higher
+* Version 2.* for Symfony 3.0 and higher
 * Version 1.2.* for Symfony 2.3
 * Version 1.1.* for Symfony 2.2
 * Version 1.0.* for Symfony 2.1 and lower

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 	},
 	"require": {
 		"php": ">=5.5.9",
-		"symfony/console": "2.*|3.*",
+		"symfony/console": "3.*",
 		"symfony/dependency-injection": "2.*|3.*"
 	},
 	"autoload": {


### PR DESCRIPTION
As in #20, the typehint in `Wrep\Daemonizable\Command\EndlessCommand::setCode()` makes this package compatible to SF3.0, but is a major BC for SF 2.*.

This PR is **intended as a 2.0 of this package**, and 1.3 version should be removed from packagist and untagged, since it's a semver violation.

This was also commented here: https://github.com/mac-cain13/daemonizable-command/pull/18#issuecomment-163547799