### PR TITLE
Symfony 6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
 		"issues": "https://github.com/mac-cain13/daemonizable-command/issues"
 	},
 	"require": {
-		"php": "^7.2|^8.0",
-		"symfony/console": "^4.0|^5.0",
-		"symfony/dependency-injection": "^4.0|^5.0"
+		"php": ">=8.0",
+		"symfony/console": "^6.0",
+		"symfony/dependency-injection": "^6.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^8.0 || ^9.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,11 +18,4 @@
 			<directory>./tests/</directory>
 		</testsuite>
 	</testsuites>
-
-	<filter>
-		<blacklist>
-			<directory>./vendor</directory>
-			<directory>./tests</directory>
-		</blacklist>
-	</filter>
 </phpunit>

--- a/src/Wrep/Daemonizable/Command/EndlessCommand.php
+++ b/src/Wrep/Daemonizable/Command/EndlessCommand.php
@@ -26,7 +26,7 @@ abstract class EndlessCommand extends Command
     private $lastPeakUsage;
 
     /**
-     * @see Symfony\Component\Console\Command\Command::__construct()
+     * @see Command::__construct()
      */
     public function __construct(string $name = null)
     {
@@ -50,7 +50,7 @@ abstract class EndlessCommand extends Command
     }
 
     /**
-     * @see Symfony\Component\Console\Command\Command::run()
+     * @see Command::run()
      */
     public function run(InputInterface $input, OutputInterface $output): int
     {
@@ -213,9 +213,9 @@ abstract class EndlessCommand extends Command
     }
 
     /**
-     * @see Symfony\Component\Console\Command\Command::setCode()
+     * @see Command::setCode()
      */
-    public function setCode(callable $code)
+    public function setCode(callable $code): static
     {
         // Exact copy of our parent
         // Makes sure we can access to call it every iteration


### PR DESCRIPTION
Tests passed:

```
docker run --net=host --rm -v `pwd`:/app daemonizable-command-8.0 ./vendor/bin/phpunit tests
PHPUnit 9.5.10 by Sebastian Bergmann and contributors.

..........                                                        10 / 10 (100%)

Time: 00:00.014, Memory: 6.00 MB

OK (10 tests, 17 assertions)
```

BC Break:

```
public function setCode(callable $code): static
```

