### PR TITLE
Add support for Symfony 7 given removal of `ContainerAwareInterface`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Use composer to include it into your Symfony project:
 
 ### What version to use?
 Symfony did make some breaking changes, so you should make sure to use a compatible bundle version:
-* Version 4.0.* for Symfony 6 and higher
+* Version 5.0.* for Symfony 7 and higher
+* Version 4.0.* for Symfony 6
 * Version 3.0.* for Symfony 4 and 5
 * Version 2.0.* for Symfony 3
 * Version 1.3.* for Symfony 2.8+


### PR DESCRIPTION
Marking this as a draft since I'm not using the doctrine removal inside the project + might require some intermediary steps, e.g. a deprecation notice inside the library to make the upgrade path from 6.* -> 7.* easier. 