### PR TITLE
Add gitattributes to remove a few files from composer install

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/tests            export-ignore
+.gitattributes    export-ignore
+.gitignore        export-ignore
+.travis.yml       export-ignore
+phpunit.xml.dist  export-ignore


### PR DESCRIPTION
It's not a huge amount, but shaves off a few files on every composer install (see https://php.watch/articles/composer-gitattributes for more information), so that the vendor directory has fewer files.