### PR TITLE
Add GitHub actions for forward version checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # See https://symfony.com/releases & https://www.php.net/supported-versions.php
+          - php-version: '8.2'
+            symfony-version: '^7.0'
+          - php-version: '8.3'
+            symfony-version: '^7.0'
+          - php-version: '8.4'
+            symfony-version: '^7.0'
+          - php-version: '8.4'
+            symfony-version: '^8.0'
+          - php-version: '8.5'
+            symfony-version: '^7.0'
+          - php-version: '8.5'
+            symfony-version: '^8.0'
+
+    name: "PHPUnit tests, PHP version ${{ matrix.php-version }} - Symfony Version: ${{matrix.symfony-version}}"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          tools: composer
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.composer/cache
+            vendor
+          key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            composer-${{ runner.os }}-${{ matrix.php-version }}-
+
+      - name: Install specific symfony version
+        run: composer require symfony/console:${{matrix.symfony-version}} symfony/dependency-injection:${{matrix.symfony-version}} -W
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit -v

--- a/.github/workflows/symfony-beta-ci.yml
+++ b/.github/workflows/symfony-beta-ci.yml
@@ -1,0 +1,45 @@
+name: "Run Symfony beta version(s)"
+description: Runs on the latest beta version so that any breaking changes can be known about a bit in advanced.
+on:
+  schedule:
+    - cron: "0 7 1 * *"
+
+jobs:
+  test-beta:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - php-version: '8.4'
+            symfony-version: '^8.1'
+          - php-version: '8.5'
+            symfony-version: '^8.1'
+
+    name: "PHPUnit tests, PHP version ${{ matrix.php-version }} - Symfony Version: ${{matrix.symfony-version}}"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          tools: composer
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.composer/cache
+            vendor
+          key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            composer-${{ runner.os }}-${{ matrix.php-version }}-
+
+      - name: Allow beta/dev versions of packages
+        run: composer config minimum-stability dev
+
+      - name: Install specific symfony version
+        run: composer require symfony/console:${{matrix.symfony-version}} symfony/dependency-injection:${{matrix.symfony-version}} -W
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit -v

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
+<!-- https://docs.phpunit.de/en/9.6/configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+		 backupGlobals="false"
 		 backupStaticAttributes="false"
 		 colors="true"
 		 convertErrorsToExceptions="true"

--- a/tests/Wrep/Daemonizable/Command/EndlessCommandRunloopTest.php
+++ b/tests/Wrep/Daemonizable/Command/EndlessCommandRunloopTest.php
@@ -19,7 +19,14 @@ class EndlessCommandRunloopTest extends TestCase
         $command = new TestEndlessCommand();
         
         $application = new Application();
-        $application->add($command);
+
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand($command);
+        } else {
+            // FIXME: Once symfony/console:8.0 is the minimum required version we can drop the add
+            $application->add($command);
+        }
+
         $application->setAutoExit(false);
         
         $input = new ArrayInput([


### PR DESCRIPTION
As suggested a while back / in issue form #64 

Adds in a couple of GitHub actions to 

* run tests over php + supported symfony versions  (note, that will require #63 to be installable without ignores)
* run tests over the beta version once a month, so that if there's an issue that'll be a breaking change, it can be mitigated before it goes live so this can be readier to go.


(also add in a small change to the phpunit config so that it should in editor know what rules are valid + links to the used version's docs)

(tested this locally + inside my fork)